### PR TITLE
Bug fix #18: worker container not use GPU resourse to run tensorflow

### DIFF
--- a/framework/docker/Dockerfile.worker
+++ b/framework/docker/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:latest-gpu
+FROM tensorflow/tensorflow:1.4.1-gpu-py3
 
 MAINTAINER JiaKuan Su <feabries@gmail.com>
 

--- a/framework/requirements.worker.txt
+++ b/framework/requirements.worker.txt
@@ -2,5 +2,4 @@ asyncio-nats-client
 aioredis
 numpy
 six
-tensorflow
-tensorflow-gpu
+tensorflow-gpu==1.4.1


### PR DESCRIPTION
The worker uses TensorFlow for inference. The dockerized version may have bugs that TensorFlow uses CPU only. In this pull request, I fixed the bugs by:
1. Only use *tensorflow-gpu* in `requirements.worker.txt`.
2. Use fixed versions of TensorFlow.