### PR TITLE
Timestamp as a float number

### DIFF
--- a/apps/tripwire/worker/modules.py
+++ b/apps/tripwire/worker/modules.py
@@ -416,7 +416,7 @@ class VideoRecordModule(IModule):
         image = blob.fetch(self._image_name)
         im_width = image.shape[1]
         im_height = image.shape[0]
-        timestamp = str(blob.fetch('timestamp'))
+        timestamp = float(blob.fetch('timestamp'))
         mode = int(blob.fetch('mode'))
 
         # Check the dimension of image tensor.
@@ -494,7 +494,7 @@ class OutputModule(IModule):
         """The routine of module execution."""
         for blob in blobs:
             mode = int(blob.fetch('mode'))
-            timestamp = str(blob.fetch('timestamp'))
+            timestamp = float(blob.fetch('timestamp'))
             if mode == _MODE.ALERT_START:
                 video_name = str(blob.fetch('video_name'))
                 triggered = blob.fetch('in_region_labels').tolist()

--- a/apps/tripwire/worker/worker.py
+++ b/apps/tripwire/worker/worker.py
@@ -103,7 +103,7 @@ def _send_event(name, timestamp, content):
 
     Args:
       name (string): The event name.
-      timestamp (string): The timestamp of the event.
+      timestamp (float): The timestamp of the event.
       content (dict): The event content.
     """
     logging.info('From Mocked send_event with event name: "{}", timestamp: "{}"'

--- a/framework/jagereye/streaming/capturers/stream_capturers.py
+++ b/framework/jagereye/streaming/capturers/stream_capturers.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import datetime
 import time
 
 import cv2
@@ -12,6 +11,7 @@ import numpy as np
 
 from jagereye.streaming.blob import Blob
 from jagereye.streaming.capturers.base import ICapturer
+from jagereye.util.generic import now
 
 
 class VideoStreamCapturer(ICapturer):
@@ -69,7 +69,7 @@ class VideoStreamCapturer(ICapturer):
           EOFError: If the stream ends.
         """
         success, image = self._cap.read()
-        timestamp = np.array(self._get_current_timestamp())
+        timestamp = np.array(now())
         if not success:
             raise EOFError()
 
@@ -82,13 +82,3 @@ class VideoStreamCapturer(ICapturer):
     def destroy(self):
         """The routine of video stream capturer destruction."""
         self._cap.release()
-
-    def _get_current_timestamp(self):
-        """Get current timestamp.
-
-        Returns:
-          string: Current timestamp.
-        """
-        t = time.time()
-        timestamp = datetime.datetime.fromtimestamp(t)
-        return str(timestamp)

--- a/framework/jagereye/streaming/capturers/stream_capturers_test.py
+++ b/framework/jagereye/streaming/capturers/stream_capturers_test.py
@@ -4,12 +4,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import datetime
 import os
 
 import pytest
 
 from jagereye.streaming.capturers.stream_capturers import VideoStreamCapturer
+from jagereye.util.generic import now
 
 
 class TestVideoStreamCapturer(object):
@@ -38,11 +38,8 @@ class TestVideoStreamCapturer(object):
         assert image.shape[1] == 320
         assert image.shape[2] == 3
         # Test the timestamp.
-        timestamp = str(blob.fetch('timestamp'))
-        date_timestamp = datetime.datetime.strptime(timestamp, '%Y-%m-%d %H:%M:%S.%f')
-        date_now = datetime.datetime.now()
-        time_delta = (date_now - date_timestamp).total_seconds()
-        assert time_delta < 0.2
+        timestamp = float(blob.fetch('timestamp'))
+        assert (now() - timestamp) < 0.2
 
         capturer.destroy()
 

--- a/framework/jagereye/util/generic.py
+++ b/framework/jagereye/util/generic.py
@@ -1,7 +1,19 @@
+"""Generic utilities."""
+
 import inspect
+import time
+
 
 def get_func_name():
     """ get the function name when inside the current function
     """
     return inspect.stack()[1][3] + str('()')
 
+
+def now():
+    """Get current time.
+
+    Returns:
+      float: Current time.
+    """
+    return time.time()

--- a/framework/jagereye/util/generic.py
+++ b/framework/jagereye/util/generic.py
@@ -11,9 +11,9 @@ def get_func_name():
 
 
 def now():
-    """Get current time.
+    """Get current timestamp.
 
     Returns:
-      float: Current time.
+      float: Current timestamp.
     """
     return time.time()

--- a/framework/jagereye/worker/worker.py
+++ b/framework/jagereye/worker/worker.py
@@ -126,7 +126,7 @@ class Worker(object):
 
         Args:
           name (string): The event name.
-          timestamp (string): The timestamp of the event.
+          timestamp (float): The timestamp of the event.
           content (dict): The event content.
         """
         logging.debug('Try to send event (name = "{}", timestamp = "{}", content'


### PR DESCRIPTION
Originally, timestamp is a string with date format. In this pull request, I modified timestamp as a float number.