### PR TITLE
Relative and absolute path of worker files directory

### DIFF
--- a/apps/tripwire/worker/modules.py
+++ b/apps/tripwire/worker/modules.py
@@ -399,7 +399,9 @@ class VideoRecordModule(IModule):
         """Create a new `VideoRecordModule`.
 
         Args:
-          files_dir (string): The directory to store the output video.
+          files_dir (dict): The directory to store the output video. It has two
+            items: "abs" for absolute path, "relative" for realtive path to the
+            shared root directory.
           reserved_count (int): The number of reseved images before alert mode.
           fps (int): The FPS of recorded video.
           video_format (string): The format of video. Defaults to "mp4".
@@ -417,6 +419,17 @@ class VideoRecordModule(IModule):
         self._reserved_images = []
         self._video_recorder = None
         self._queue = None
+
+    def _abs_file_name(self, file_name):
+        """Get absolute file name for a given file name.
+        """
+        print(self._files_dir)
+        return os.path.join(self._files_dir['abs'], file_name)
+
+    def _relative_file_name(self, file_name):
+        """Get relative file name for a given file name.
+        """
+        return os.path.join(self._files_dir['relative'], file_name)
 
     def prepare(self):
         """The routine of module preparation."""
@@ -440,16 +453,19 @@ class VideoRecordModule(IModule):
 
         # Handle alert mode.
         if mode == _MODE.ALERT_START:
-            if not os.path.exists(self._files_dir):
-                os.makedirs(self._files_dir)
-            video_name = '{}.{}'.format(timestamp, self._video_format)
-            video_name = os.path.join(self._files_dir, video_name)
-            thumbnail_name = '{}.{}'.format(timestamp, self._thumbnail_format)
-            thumbnail_name = os.path.join(self._files_dir, thumbnail_name)
+            if not os.path.exists(self._files_dir['abs']):
+                os.makedirs(self._files_dir['abs'])
+
+            video_file = '{}.{}'.format(timestamp, self._video_format)
+            abs_video_name = self._abs_file_name(video_file)
+            relative_video_name = self._relative_file_name(video_file)
+            thumbnail_file = '{}.{}'.format(timestamp, self._thumbnail_format)
+            abs_thumbnail_name = self._abs_file_name(thumbnail_file)
+            relative_thumbnail_name = self._relative_file_name(thumbnail_file)
             video_size = (im_width, im_height)
             self._queue = Queue()
-            args = (video_name,
-                    thumbnail_name,
+            args = (abs_video_name,
+                    abs_thumbnail_name,
                     self._fps,
                     video_size,
                     self._queue,)
@@ -468,8 +484,8 @@ class VideoRecordModule(IModule):
                 'image': image,
                 'thumbnail': True
             })
-            blob.feed('video_name', np.array(video_name))
-            blob.feed('thumbnail_name', np.array(thumbnail_name))
+            blob.feed('video_name', np.array(relative_video_name))
+            blob.feed('thumbnail_name', np.array(relative_thumbnail_name))
         elif mode == _MODE.ALERTING:
             self._queue.put({
                 'command': 'RECORD',

--- a/apps/tripwire/worker/modules.py
+++ b/apps/tripwire/worker/modules.py
@@ -423,7 +423,6 @@ class VideoRecordModule(IModule):
     def _abs_file_name(self, file_name):
         """Get absolute file name for a given file name.
         """
-        print(self._files_dir)
         return os.path.join(self._files_dir['abs'], file_name)
 
     def _relative_file_name(self, file_name):

--- a/apps/tripwire/worker/worker.py
+++ b/apps/tripwire/worker/worker.py
@@ -116,8 +116,13 @@ def main(worker_id, standalone = False, params=None):
         worker.register_pipeline(worker_fn)
         worker.start()
     else:
-        files_dir = os.path.join('~/jagereye_shared', WORKER_NAME, worker_id)
-        files_dir = os.path.expanduser(files_dir)
+        relative_files_dir = os.path.join(WORKER_NAME, worker_id)
+        abs_files_dir = os.path.join('~/jagereye_shared', relative_files_dir)
+        abs_files_dir = os.path.expanduser(abs_files_dir)
+        files_dir = {
+            'abs': abs_files_dir,
+            'relative': relative_files_dir
+        }
         worker_fn(params, files_dir, _send_event)
 
 

--- a/framework/jagereye/worker/worker.py
+++ b/framework/jagereye/worker/worker.py
@@ -32,8 +32,13 @@ class Worker(object):
         self._mem_db_cli = None
         self._name = name
         self._worker_id = worker_id
-        files_dir = os.path.join(shared_dir, name, worker_id)
-        self._files_dir = os.path.expanduser(files_dir)
+        relative_files_dir = os.path.join(name, worker_id)
+        abs_files_dir = os.path.join(shared_dir, relative_files_dir)
+        abs_files_dir = os.path.expanduser(abs_files_dir)
+        self._files_dir = {
+            'abs': abs_files_dir,
+            'relative': relative_files_dir
+        }
         self._ch_worker_to_brain = self._gen_ch_WtoB() 
         self._ch_brain_to_worker = self._gen_ch_BtoW()
         self._event_queue_key = 'event:brain:{}'.format(worker_id)


### PR DESCRIPTION
Each worker has its own directory to store static files. Originally, the directory is absolute, for example: `/home/jager/jagereye_shared/tripwire/worker_id`. The problem of absolute directory is when the directory information is stored in events, web front-end cannot get the static files from the absolute paths. What we need is relative paths, for example: `tripwire/worker_id`, to let front-end know how to get the files. So in this pull request, I modified *Worker* to make it has both relative and absolute path information.