### PR TITLE
Save original video clips and metadata for events

### DIFF
--- a/apps/tripwire/worker/worker.py
+++ b/apps/tripwire/worker/worker.py
@@ -74,6 +74,8 @@ def worker_fn(params, files_dir, send_event):
         region[1]['y']
     )
     triggers = config['triggers']
+    metadata_frame_names = ['mode', 'labels', 'boxes', 'scores']
+    metadata_custom_names = ['region']
 
     pipeline = Pipeline(cap_interval=cap_interval)
 
@@ -84,15 +86,17 @@ def worker_fn(params, files_dir, send_event):
                                           region_tuple,
                                           triggers)) \
             .pipe(TripwireModeModule(reserved_count=reserved_count)) \
-            .pipe(DrawTripwireModule(region_tuple, normal_color, alert_color)) \
             .pipe(VideoRecordModule(files_dir,
                                     reserved_count,
                                     FPS,
-                                    image_name='drawn_image')) \
+                                    save_metadata=True,
+                                    metadata_frame_names=metadata_frame_names,
+                                    metadata_custom_names=metadata_custom_names)) \
             .pipe(OutputModule(send_event))
 
     if VISUALIZE:
-        pipeline.pipe(DisplayModule(image_name='drawn_image'))
+        pipeline.pipe(DrawTripwireModule(region_tuple, normal_color, alert_color)) \
+                .pipe(DisplayModule(image_name='drawn_image'))
 
     pipeline.start()
     pipeline.await_termination()

--- a/apps/tripwire/worker/worker.py
+++ b/apps/tripwire/worker/worker.py
@@ -91,7 +91,9 @@ def worker_fn(params, files_dir, send_event):
                                      normal_color,
                                      alert_color,
                                      always_draw=VISUALIZE)) \
-            .pipe(ImageSaveModule(files_dir, image_name='drawn_image')) \
+            .pipe(ImageSaveModule(files_dir,
+                                  max_width=300,
+                                  image_name='drawn_image')) \
             .pipe(VideoRecordModule(files_dir,
                                     reserved_count,
                                     FPS,

--- a/apps/tripwire/worker/worker.py
+++ b/apps/tripwire/worker/worker.py
@@ -5,6 +5,7 @@ import os
 import sys
 
 from jagereye.util import logging
+from jagereye.streaming import ImageSaveModule
 from jagereye.streaming import VideoStreamCapturer
 from jagereye.streaming import DisplayModule
 from jagereye.streaming import Pipeline
@@ -86,6 +87,11 @@ def worker_fn(params, files_dir, send_event):
                                           region_tuple,
                                           triggers)) \
             .pipe(TripwireModeModule(reserved_count=reserved_count)) \
+            .pipe(DrawTripwireModule(region_tuple,
+                                     normal_color,
+                                     alert_color,
+                                     always_draw=VISUALIZE)) \
+            .pipe(ImageSaveModule(files_dir, image_name='drawn_image')) \
             .pipe(VideoRecordModule(files_dir,
                                     reserved_count,
                                     FPS,
@@ -95,8 +101,7 @@ def worker_fn(params, files_dir, send_event):
             .pipe(OutputModule(send_event))
 
     if VISUALIZE:
-        pipeline.pipe(DrawTripwireModule(region_tuple, normal_color, alert_color)) \
-                .pipe(DisplayModule(image_name='drawn_image'))
+        pipeline.pipe(DisplayModule(image_name='drawn_image'))
 
     pipeline.start()
     pipeline.await_termination()

--- a/framework/jagereye/streaming/__init__.py
+++ b/framework/jagereye/streaming/__init__.py
@@ -11,6 +11,7 @@ from jagereye.streaming.blob import Blob
 from jagereye.streaming.modules.base import IModule
 from jagereye.streaming.modules.grayscale_modules import GrayscaleModule
 from jagereye.streaming.modules.display_modules import DisplayModule
+from jagereye.streaming.modules.io_modules import ImageSaveModule
 
 # Capturers
 from jagereye.streaming.capturers.base import ICapturer
@@ -27,6 +28,7 @@ __all__ = [
     'IModule',
     'GrayscaleModule',
     'DisplayModule',
+    'ImageSaveModule',
     # Capturers
     'ICapturer',
     'VideoStreamCapturer',

--- a/framework/jagereye/streaming/modules/io_modules.py
+++ b/framework/jagereye/streaming/modules/io_modules.py
@@ -1,0 +1,98 @@
+"""Modules to manipulate I/O."""
+
+import os
+
+import cv2
+import numpy as np
+
+from jagereye.streaming.modules.base import IModule
+from jagereye.util import logging
+
+
+def _abs_file_name(files_dir, file_name):
+    """Get absolute file name for a given file name.
+
+    Args:
+      files_dir (dict): The directory to store the output file. It has two
+        items: "abs" for absolute path, "relative" for realtive path to the
+        shared root directory.
+      file_name (string): The name of file to store.
+
+    Returns:
+      string: The absolute file name.
+    """
+    return os.path.join(files_dir['abs'], file_name)
+
+
+def _relative_file_name(files_dir, file_name):
+    """Get relative file name for a given file name.
+
+    Args:
+      files_dir (dict): The directory to store the output file. It has two
+        items: "abs" for absolute path, "relative" for realtive path to the
+        shared root directory.
+      file_name (string): The name of file to store.
+
+    Returns:
+      string: The relative file name.
+    """
+    return os.path.join(files_dir['relative'], file_name)
+
+
+class ImageSaveModule(IModule):
+    """The module for saving images."""
+
+    def __init__(self, files_dir, image_format='jpg', image_name='image'):
+        """Create a new `ImageSaveModule`.
+
+        Args:
+          files_dir (dict): The directory to store the output video. It has two
+            items: "abs" for absolute path, "relative" for realtive path to the
+            shared root directory.
+          image_format (string): The format of image to save. Defaults to "jpg".
+          image_name (string): The name of input tensor to read. Defaults to
+            "image".
+
+        Raises:
+            RuntimeError: If the input tensor is not 2 or 3-dimensional.
+        """
+        self._files_dir = files_dir
+        self._image_format = image_format
+        self._image_name = image_name
+
+    def prepare(self):
+        """The routine of module preparation."""
+        pass
+
+    def execute(self, blobs):
+        """The routine of module execution to save images."""
+        # TODO(JiaKuan Su): Currently, I only handle the case for batch_size=1,
+        # please help complete the case for batch_size>1.
+        blob = blobs[0]
+
+        if blob.has('to_save') and blob.fetch('to_save').tolist():
+            image = blob.fetch(self._image_name)
+            timestamp = blob.fetch('timestamp').tolist()
+
+            if image.ndim != 2 and image.ndim != 3:
+                raise RuntimeError('The input "image" tensor is not '
+                                   '3-dimensional.')
+
+            # Construct the image file name.
+            image_file = '{}.{}'.format(timestamp, self._image_format)
+            abs_image_name = _abs_file_name(self._files_dir, image_file)
+            relative_image_name = _relative_file_name(self._files_dir,
+                                                      image_file)
+            # Save Image to disk.
+            cv2.imwrite(abs_image_name, image)
+            logging.info('Save image: {}'.format(abs_image_name))
+
+            # Feed the relative image file name to blob.
+            blob.feed('abs_image_name', np.array(abs_image_name))
+            blob.feed('relative_image_name', np.array(relative_image_name))
+
+        return blobs
+
+    def destroy(self):
+        """The routine of module destruction."""
+        pass

--- a/framework/jagereye/streaming/modules/io_modules.py
+++ b/framework/jagereye/streaming/modules/io_modules.py
@@ -40,7 +40,30 @@ def _relative_file_name(files_dir, file_name):
 
 
 class ImageSaveModule(IModule):
-    """The module for saving images."""
+    """The module for saving images.
+
+    The module is to save an image for each blob. The module only saves an image
+    when the input blob contains boolean tensor "to_save" and its value is True.
+    When saving an image, the input blob must contains a tensor whose default
+    name is "image" and "timestamp", and the output blob will be fed
+    a "abs_image_name" tensor and a "relative_image_name" tensor to store the
+    absolute and relative file name separately. Users can also specify the name
+    of input tensor such as "gray_image" instead of the default name.
+
+    The dimension of input "to_save" tensor should be 0 and its type is bool.
+
+    The dimension of input "image" tensor must be a 2 (grayscale) or 3 (BGR) and
+    its type is unit8. The shape format is:
+    1. Image height.
+    2. Image width.
+    3. (Only for 3-dimensional tensor) Number of channels, which is usually 3.
+
+    The dimension of input "timestamp" tensor should be 0 and its type is
+    float64.
+
+    The output "abs_image_name" and "relative_image_name" tensor are both
+    0-dimensional numpy `ndarray`.
+    """
 
     def __init__(self,
                  files_dir,
@@ -61,9 +84,6 @@ class ImageSaveModule(IModule):
             image is unlimited. Defaults to 0.
           image_name (string): The name of input tensor to read. Defaults to
             "image".
-
-        Raises:
-            RuntimeError: If the input tensor is not 2 or 3-dimensional.
         """
         self._files_dir = files_dir
         self._image_format = image_format
@@ -75,7 +95,22 @@ class ImageSaveModule(IModule):
         pass
 
     def execute(self, blobs):
-        """The routine of module execution to save images."""
+        """The routine of module execution to save images.
+
+        Args:
+          blobs (list of `Blob`): The input blobs for execution. When saving,
+            each blob must contains a 0-dimensional "to_save" tensor whose value
+            is True, a 2 or 3-dimensional tensor whose default name is "image",
+            and a 0-dimensional "timestamp" tensor.
+
+        Returns:
+          list of `Blob`: The executed blobs. When saving, Each blob will be fed
+          a "abs_image_name" and a "relative_image_name" tensor. The tensor are
+          both 0-dimensional.
+
+        Raises:
+            RuntimeError: If the input "image" tensor is not 2 or 3-dimensional.
+        """
         # TODO(JiaKuan Su): Currently, I only handle the case for batch_size=1,
         # please help complete the case for batch_size>1.
         blob = blobs[0]


### PR DESCRIPTION
When an event occur, most of our applications save a video clip for that event. Originally, the video clip is drawn with some application-defined objects. For example, tripwire application draw the region on each video clip. The problem of such pre-drawing method is it it hard to collect the original data, i.e. the raw video clip. I this pull request, I solved the problems by store the raw video clips and their related detailed metadata, as discussed in #65.

What I have done in this pull request is shown as follows:
- Save metadata in `VideoRecordModule`
- Remove the thumbnail saving function from `VideoRecordModule` and make a new module `ImageSaveModule`